### PR TITLE
pin pyyaml version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-yamale~=4.0.2
+pyyaml==5.3.1
+yamale~=4.0.4


### PR DESCRIPTION
There is an issue with v6 PyYaml on alpine images thanks to some version misalignment with Cython. Pinning here should avoid the issues for now.